### PR TITLE
Expand installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Julia-Dash App produces graphs of the request statistics for Julia Packages
 
 ![Julia Packages App](JuliaPackages.gif)
 
-You can run the app with
+You can run the app from the command line & Julia REPL by typing
 
 ```
 $ git clone https://github.com/valerocar/JuliaPackages.jl

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ This Julia-Dash App produces graphs of the request statistics for Julia Packages
 
 ![Julia Packages App](JuliaPackages.gif)
 
-You can run the app from the Julia REPL by typing
+You can run the app with
 
 ```
+$ git clone https://github.com/valerocar/JuliaPackages.jl
+$ cd JuliaPackages.jl
+$ julia
 julia> using Pkg
 julia> Pkg.activate(".")
 julia> Pkg.instantiate()


### PR DESCRIPTION
Because this is a .jl github repository that is not added via the package manager, I think it is a good idea to be explicit about how one is to install it.